### PR TITLE
Add support for multiple account holders (pt-BR: Conta conjunta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Options:
       --version      Show version number                               [boolean]
   -b, --branch       Itaú branch number, format: 0000        [string] [required]
   -c, --account      Itaú account number, format: 00000-0    [string] [required]
+  -n, --name         Itaú account name, format: Joao                    [string]
   -p, --password     Itaú account digital password(6 digits) [number] [required]
   -d, --days         Transaction log days
                           [number] [required] [choices: 3, 5, 7, 15, 30, 60, 90]

--- a/itauscraper.js
+++ b/itauscraper.js
@@ -18,6 +18,23 @@ const stepLogin = async (page, options) => {
   await page.waitForTimeout(500)
   await page.click('#btnLoginSubmit')
 
+  if(!!options.name){
+    console.log('Opening account holder page...');
+    await page.waitForTimeout(2000)
+    await stepAwaitRegularLoading(page)
+    await page.waitForSelector('ul.selecao-nome-titular', { visible: true })
+    console.log('Account holder page loaded.')
+
+    const names = await page.$$('ul.selecao-nome-titular a[role="button"]');
+    for (const name of names) {
+      const text = await page.evaluate(element => element.textContent, name);
+      if(text.toUpperCase() == options.name.toUpperCase()){
+        name.click();
+        console.log('Account holder selected.')
+      }
+    }
+  }
+
   console.log('Opening password page...')
   await page.waitForTimeout(2000)
   await stepAwaitRegularLoading(page)

--- a/itauscraper.js
+++ b/itauscraper.js
@@ -16,7 +16,7 @@ const stepLogin = async (page, options) => {
   await page.type('#conta', options.account)
   console.log('Account and branch number has been filled.')
   await page.waitForTimeout(500)
-  await page.click('#btnLoginSubmit')
+  await page.click('#loginButton')
 
   if(!!options.name){
     console.log('Opening account holder page...');

--- a/run.js
+++ b/run.js
@@ -22,6 +22,11 @@ const argv = require('yargs')
     required: true,
     type: 'number'
   })
+  .option('name', {
+    alias: 'n',
+    describe: 'Itaú account holder name, format: Joao',
+    type: 'string'
+  })
   .option('days', {
     alias: 'd',
     describe: 'Transaction log days',
@@ -44,6 +49,7 @@ const argv = require('yargs')
 // Config
 nconf.env({ lowerCase: true }).argv(argv)
 const environment = nconf.get('node_env')
+console.log(environment)
 nconf.file(environment, './config/' + environment.toLowerCase() + '.json')
 nconf.file('default', './config/default.json')
 
@@ -52,3 +58,4 @@ const options = nconf.get()
 console.log('Starting using node environment: ' + environment)
 // Run
 itauscraper(options)
+ 


### PR DESCRIPTION
This PR add supports to accounts with multiple account holders. Use the `-n, --name` argument.